### PR TITLE
feat(sidecar-terminator): added initial helm chart (#217)

### DIFF
--- a/stable/sidecar-terminator/.helmignore
+++ b/stable/sidecar-terminator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/sidecar-terminator/Chart.yaml
+++ b/stable/sidecar-terminator/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+appVersion: "1.0.0"
+description: |-
+  A chart used for easily configuring kubernetes-sidecar-terminator in a cluster.
+name: sidecar-terminator
+version: 1.0.0
+keywords:
+- sidecar-terminator
+sources:
+- https://gitlab.k8s.cloud.statcan.ca/cloudnative/terraform/modules/terraform-kubernetes-sidecar-terminator
+maintainers:
+- name: Mohamed Dahrouj
+  email: mohamed.dahrouj@statcan.gc.ca
+home: https://www.statcan.gc.ca

--- a/stable/sidecar-terminator/templates/_helpers.tpl
+++ b/stable/sidecar-terminator/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sidecar-terminator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sidecar-terminator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sidecar-terminator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "sidecar-terminator.labels" -}}
+helm.sh/chart: {{ include "sidecar-terminator.chart" . }}
+app.kubernetes.io/name: {{ include "sidecar-terminator.fullname" . }}
+{{ include "sidecar-terminator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "sidecar-terminator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sidecar-terminator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/stable/sidecar-terminator/templates/clusterrole.yaml
+++ b/stable/sidecar-terminator/templates/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "sidecar-terminator.fullname" . }}
+  labels:
+    {{- include "sidecar-terminator.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get","list","watch"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]

--- a/stable/sidecar-terminator/templates/clusterrolebinding.yaml
+++ b/stable/sidecar-terminator/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "sidecar-terminator.fullname" . }}
+  labels:
+    {{- include "sidecar-terminator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "sidecar-terminator.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "sidecar-terminator.fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/stable/sidecar-terminator/templates/deployment.yaml
+++ b/stable/sidecar-terminator/templates/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sidecar-terminator.fullname" . }}
+  labels:
+    {{- include "sidecar-terminator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "sidecar-terminator.fullname" . }}
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "sidecar-terminator.fullname" . }}
+    spec:
+      serviceAccountName: {{ include "sidecar-terminator.fullname" . }}
+      containers:
+      - image: {{ .Values.image.repository }}
+        name: sidecar-terminator
+        resources:
+          requests:
+            cpu: {{ .Values.resources.requests.cpu }}
+            memory: {{ .Values.resources.requests.memory }}
+          limits:
+            cpu: {{ .Values.resources.limits.cpu }}
+            memory: {{ .Values.resources.limits.memory }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/stable/sidecar-terminator/templates/role.yaml
+++ b/stable/sidecar-terminator/templates/role.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "sidecar-terminator.fullname" . }}
+  labels:
+    {{- include "sidecar-terminator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - sidecar-terminator
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+  - watch
+  - patch

--- a/stable/sidecar-terminator/templates/rolebinding.yaml
+++ b/stable/sidecar-terminator/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "sidecar-terminator.fullname" . }}
+  labels:
+    {{- include "sidecar-terminator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "sidecar-terminator.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "sidecar-terminator.fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/stable/sidecar-terminator/templates/serviceaccount.yaml
+++ b/stable/sidecar-terminator/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sidecar-terminator.fullname" . }}
+  labels:
+    {{- include "sidecar-terminator.labels" . | nindent 4 }}

--- a/stable/sidecar-terminator/values.yaml
+++ b/stable/sidecar-terminator/values.yaml
@@ -1,0 +1,39 @@
+# Default values for sidecar-terminator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: zachomedia/kubernetes-sidecar-terminator
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  requests:
+    cpu: 10m
+    memory: 200M
+  limits:
+    cpu: 100m
+    memory: 500M
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
* feat(sidecar-terminator): added initial helm chart

* feat(sidecar-terminator): added initial helm chart

* feat(sidecar-terminator): removed chart icon

* Update stable/sidecar-terminator/templates/clusterrolebinding.yaml

Co-authored-by: Justin Bertrand <justin.m.bertrand@gmail.com>

* Update stable/sidecar-terminator/templates/deployment.yaml

Co-authored-by: Justin Bertrand <justin.m.bertrand@gmail.com>

* Update stable/sidecar-terminator/templates/rolebinding.yaml

Co-authored-by: Justin Bertrand <justin.m.bertrand@gmail.com>

* Update stable/sidecar-terminator/templates/role.yaml

Co-authored-by: Justin Bertrand <justin.m.bertrand@gmail.com>

* Update stable/sidecar-terminator/templates/rolebinding.yaml

Co-authored-by: Justin Bertrand <justin.m.bertrand@gmail.com>

* Update stable/sidecar-terminator/templates/serviceaccount.yaml

Co-authored-by: Justin Bertrand <justin.m.bertrand@gmail.com>

* feat(sidecar-terminator): removed redundant namespace value

* feat(sidecar-terminator): added ability to scale

Co-authored-by: mohamed.dahrouj@cloud.statcan.ca <mohamed.dahrouj@statcan.gc.ca>
Co-authored-by: Justin Bertrand <justin.m.bertrand@gmail.com>